### PR TITLE
[3주차 slack clone] Namespace, Room

### DIFF
--- a/2. slack clone/classes/Namespace.js
+++ b/2. slack clone/classes/Namespace.js
@@ -1,0 +1,15 @@
+class Namespace {
+    constructor(id, name, image, endpoint) {
+        this.id = id;
+        this.name = name;
+        this.image = image;
+        this.endpoint = endpoint;
+        this.rooms = [];
+    }
+
+    addRoom(roomObj) {
+        this.rooms.push(roomObj);
+    }
+}
+
+module.exports = Namespace;

--- a/2. slack clone/classes/Room.js
+++ b/2. slack clone/classes/Room.js
@@ -1,0 +1,19 @@
+class Room {
+    constructor(roomId, roomTitle, namespaceId, privateRoom = false) {
+        this.roomId = roomId;
+        this.roomTitle = roomTitle;
+        this.namespaceId = namespaceId;
+        this.privateRoom = privateRoom;
+        this.history = [];
+    }
+
+    addMessage(message) {
+        this.history.push(message);
+    }
+
+    clearHistory() {
+        this.history = [];
+    }
+}
+
+module.exports = Room;

--- a/2. slack clone/data/namespace.js
+++ b/2. slack clone/data/namespace.js
@@ -1,16 +1,23 @@
-const wikiNs = {
-    ns: '/wiki',
-    image: 'https://upload.wikimedia.org/wikipedia/en/thumb/8/80/Wikipedia-logo-v2.svg/103px-Wikipedia-logo-v2.svg.png'
-}
-const mozNs = {
-    ns: '/mozilla',
-    image: 'https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png'
-}
-const linuxNx = {
-    ns: '/linux',
-    image: 'https://upload.wikimedia.org/wikipedia/commons/a/af/Tux.png'
-}
+const Namespace = require('../classes/Namespace');
+const Room = require('../classes/Room');
 
-const namespaces = [wikiNs, mozNs, linuxNx];
+const wikiNs = new Namespace(0, 'Wikipedia', 'https://upload.wikimedia.org/wikipedia/en/thumb/8/80/Wikipedia-logo-v2.svg/103px-Wikipedia-logo-v2.svg.png', '/wiki');
+const mozNs = new Namespace(1, 'Mozilla', 'https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png', '/mozilla');
+const linuxNs = new Namespace(2, 'Linux', 'https://upload.wikimedia.org/wikipedia/commons/a/af/Tux.png','linux');
+
+wikiNs.addRoom(new Room(0, '스터디룸', 0));
+wikiNs.addRoom(new Room(1, '공부방', 0));
+wikiNs.addRoom(new Room(2, '수다방', 0));
+
+mozNs.addRoom(new Room(0, '연설연습방', 1));
+mozNs.addRoom(new Room(1, '벙개', 1));
+mozNs.addRoom(new Room(2, '주니어', 1));
+mozNs.addRoom(new Room(3, '헬로', 1));
+
+linuxNs.addRoom(new Room(0, '1번방', 2));
+linuxNs.addRoom(new Room(1, '2번방', 2));
+linuxNs.addRoom(new Room(2, '3번방', 2));
+
+const namespaces = [wikiNs, mozNs, linuxNs];
 
 module.exports = namespaces;

--- a/2. slack clone/data/namespace.js
+++ b/2. slack clone/data/namespace.js
@@ -1,0 +1,16 @@
+const wikiNs = {
+    ns: '/wiki',
+    image: 'https://upload.wikimedia.org/wikipedia/en/thumb/8/80/Wikipedia-logo-v2.svg/103px-Wikipedia-logo-v2.svg.png'
+}
+const mozNs = {
+    ns: '/mozilla',
+    image: 'https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png'
+}
+const linuxNx = {
+    ns: '/linux',
+    image: 'https://upload.wikimedia.org/wikipedia/commons/a/af/Tux.png'
+}
+
+const namespaces = [wikiNs, mozNs, linuxNx];
+
+module.exports = namespaces;

--- a/2. slack clone/public/joinNs.js
+++ b/2. slack clone/public/joinNs.js
@@ -1,0 +1,13 @@
+const joinNs = (element, nsData) => {
+    const nsEndpoint = element.getAttribute('ns');
+    const clickedNs = nsData.find(ns => ns.endpoint === nsEndpoint);
+    const rooms = clickedNs.rooms;
+
+    const roomList = document.querySelector('.room-list');
+    roomList.innerHTML = ``;
+    rooms.forEach(room => {
+        roomList.innerHTML += `<li><span class="glyphicon glyphicon-globe"></span>${room.roomTitle}</li>`;
+    })
+
+    localStorage.setItem('lastNs', nsEndpoint);
+}

--- a/2. slack clone/public/scripts.js
+++ b/2. slack clone/public/scripts.js
@@ -6,9 +6,24 @@ socket.on('connect', (message) => {
 })
 
 socket.on('nsList', (nsData) => {
-    console.log(nsData);
+    const lastNs = localStorage.getItem('lastNs');
+
     const nameSpacesDiv = document.querySelector('.namespaces');
+    nameSpacesDiv.innerHTML = '';
     nsData.forEach((ns) => {
-        nameSpacesDiv.innerHTML += `<div class="namespace" ns="${ns.name}"><img src="${ns.image}"></div>`;
+        nameSpacesDiv.innerHTML += `<div class="namespace" ns="${ns.endpoint}"><img src="${ns.image}"></div>`;
     })
+
+    /**
+     * 페이지 최초 진입시, namespace 및 namespace의 room 세팅
+     */
+    joinNs(document.getElementsByClassName('namespace')[0], nsData);
+
+    Array.from(document.getElementsByClassName('namespace')).forEach((element) => {
+        element.addEventListener('click', (e) => {
+            joinNs(element, nsData);
+        })
+    })
+
+
 })

--- a/2. slack clone/public/scripts.js
+++ b/2. slack clone/public/scripts.js
@@ -5,6 +5,10 @@ socket.on('connect', (message) => {
     socket.emit('clientConnected');
 })
 
-socket.emit('welcome', (data) => {
-    console.log(data);
+socket.on('nsList', (nsData) => {
+    console.log(nsData);
+    const nameSpacesDiv = document.querySelector('.namespaces');
+    nsData.forEach((ns) => {
+        nameSpacesDiv.innerHTML += `<div class="namespace" ns="${ns.name}"><img src="${ns.image}"></div>`;
+    })
 })

--- a/2. slack clone/public/slack.html
+++ b/2. slack clone/public/slack.html
@@ -10,10 +10,7 @@
                 <h6 class="pointer">
                     <i class="room-caret fa-solid fa-caret-down"></i>Rooms
                 </h6>
-                <ul class="room-list">
-                    <li><span class="glyphicon glyphicon-lock"></span>Main Room</li>
-                    <li><span class="glyphicon glyphicon-globe"></span>Meeting Room</li>
-                </ul>
+                <ul class="room-list"></ul>
             </div>
             <div class="dm">
                 <h6 class="pointer">
@@ -85,4 +82,5 @@
 </div>
 
 <script src="/socket.io/socket.io.js"></script>
+<script src="./joinNs.js"></script>
 <script src="./scripts.js"></script>

--- a/2. slack clone/public/slack.html
+++ b/2. slack clone/public/slack.html
@@ -4,11 +4,7 @@
 
 <div class="container-fluid">
     <div class="row">
-        <div class="namespaces">
-            <div class="namespace" ns="/wiki"><img src="https://upload.wikimedia.org/wikipedia/en/thumb/8/80/Wikipedia-logo-v2.svg/103px-Wikipedia-logo-v2.svg.png"></div>
-            <div class="namespace" ns="/mozilla"><img src="https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png"></div>
-            <div class="namespace" ns="/linux"><img src="https://upload.wikimedia.org/wikipedia/commons/a/af/Tux.png"></div>
-        </div>
+        <div class="namespaces"></div>
         <div class="rooms">
             <div class="main-rooms">
                 <h6 class="pointer">

--- a/2. slack clone/slack.js
+++ b/2. slack clone/slack.js
@@ -2,6 +2,8 @@ const express = require('express');
 const app = express();
 const socketio = require('socket.io');
 
+const namespaces = require('./data/namespace');
+
 app.use(express.static(__dirname + '/public'))
 
 const expressServer = app.listen(9000);
@@ -9,5 +11,11 @@ const io = socketio(expressServer);
 
 io.on('connection', (socket) => {
     console.log(socket.id, 'connected');
+
+    socket.on('clientConnected', (data) => {
+        console.log(socket.id, 'has connected');
+    })
+
+    socket.emit('nsList', namespaces)
 })
 


### PR DESCRIPTION
## 📌 프로젝트명

slack clone

## 📝 주요 구현 내용

페이지 진입시, 동적으로 Namespace와 Room이 렌더링될 수 있도록 구현했습니다.

추가로, 각 namespace를 클릭하면 해당 namespace에 속한 Room들이 렌더링될 수 있도록 구현했습니다.

## 🤔 고민한 점, 느낀점

아직은 더미 데이터로 Namespace와 Room을 그려주고 있는데, 다음 주 부터는 좀 더 기능화 해서 구현하면 재밌을 거 같네요.
