### PR TITLE
[slack clone] Namespace와 Room 관련 세부 로직 구현

### DIFF
--- a/2. slack clone/data/namespace.js
+++ b/2. slack clone/data/namespace.js
@@ -3,7 +3,7 @@ const Room = require('../classes/Room');
 
 const wikiNs = new Namespace(0, 'Wikipedia', 'https://upload.wikimedia.org/wikipedia/en/thumb/8/80/Wikipedia-logo-v2.svg/103px-Wikipedia-logo-v2.svg.png', '/wiki');
 const mozNs = new Namespace(1, 'Mozilla', 'https://www.mozilla.org/media/img/logos/firefox/logo-quantum.9c5e96634f92.png', '/mozilla');
-const linuxNs = new Namespace(2, 'Linux', 'https://upload.wikimedia.org/wikipedia/commons/a/af/Tux.png','linux');
+const linuxNs = new Namespace(2, 'Linux', 'https://upload.wikimedia.org/wikipedia/commons/a/af/Tux.png','/linux');
 
 wikiNs.addRoom(new Room(0, '스터디룸', 0));
 wikiNs.addRoom(new Room(1, '공부방', 0));

--- a/2. slack clone/public/joinNs.js
+++ b/2. slack clone/public/joinNs.js
@@ -6,7 +6,21 @@ const joinNs = (element, nsData) => {
     const roomList = document.querySelector('.room-list');
     roomList.innerHTML = ``;
     rooms.forEach(room => {
-        roomList.innerHTML += `<li><span class="glyphicon glyphicon-globe"></span>${room.roomTitle}</li>`;
+        roomList.innerHTML += `<li class="room" namespaceId=${room.namespaceId}>
+                <span class="fa-solid fa-${room.privateRoom ? 'lock' : 'globe'}"></span>
+                ${room.roomTitle}
+            </li>
+        `;
+    })
+
+    const roomNodes = document.querySelectorAll('.room');
+    Array.from(roomNodes).forEach(roomNode => {
+        roomNode.addEventListener('click', (e) => {
+            const roomTitle = e.target.innerText;
+            const nameSpaceId = roomNode.getAttribute('namespaceId');
+
+            joinRoom(roomTitle, nameSpaceId);
+        })
     })
 
     localStorage.setItem('lastNs', nsEndpoint);

--- a/2. slack clone/public/joinNs.js
+++ b/2. slack clone/public/joinNs.js
@@ -3,6 +3,8 @@ const joinNs = (element, nsData) => {
     const clickedNs = nsData.find(ns => ns.endpoint === nsEndpoint);
     const rooms = clickedNs.rooms;
 
+    selectedNsId = clickedNs.id;
+
     const roomList = document.querySelector('.room-list');
     roomList.innerHTML = ``;
 

--- a/2. slack clone/public/joinNs.js
+++ b/2. slack clone/public/joinNs.js
@@ -5,13 +5,23 @@ const joinNs = (element, nsData) => {
 
     const roomList = document.querySelector('.room-list');
     roomList.innerHTML = ``;
-    rooms.forEach(room => {
+
+    let firstRoom;
+
+    rooms.forEach((room, index) => {
+        if(index === 0) {
+            firstRoom = room.roomTitle;
+        }
+
         roomList.innerHTML += `<li class="room" namespaceId=${room.namespaceId}>
                 <span class="fa-solid fa-${room.privateRoom ? 'lock' : 'globe'}"></span>
                 ${room.roomTitle}
             </li>
         `;
     })
+
+    const currentNamespaceId = clickedNs.id;
+    joinRoom(firstRoom, currentNamespaceId);
 
     const roomNodes = document.querySelectorAll('.room');
     Array.from(roomNodes).forEach(roomNode => {

--- a/2. slack clone/public/joinRoom.js
+++ b/2. slack clone/public/joinRoom.js
@@ -1,11 +1,11 @@
-const joinRoom = (roomTitle, namespaceId) => {
+const joinRoom = async (roomTitle, namespaceId) => {
     console.log('roomTitle', roomTitle);
     console.log('namespaceId', namespaceId);
-    nameSpaceSockets[namespaceId].emit('joinRoom', roomTitle, (ackResp) => {
-        const numUsersDom = document.querySelector('.curr-room-num-users');
-        numUsersDom.innerHTML = `${ackResp.numUsers}<span class="fa-solid fa-user"></span>`
+    const ackResp = await nameSpaceSockets[namespaceId].emitWithAck('joinRoom', roomTitle);
 
-        const roomTitleDom = document.querySelector('.curr-room-text');
-        roomTitleDom.innerHTML = roomTitle;
-    });
+    const numUsersDom = document.querySelector('.curr-room-num-users');
+    numUsersDom.innerHTML = `${ackResp.numUsers}<span class="fa-solid fa-user"></span>`
+
+    const roomTitleDom = document.querySelector('.curr-room-text');
+    roomTitleDom.innerHTML = roomTitle;
 };

--- a/2. slack clone/public/joinRoom.js
+++ b/2. slack clone/public/joinRoom.js
@@ -1,5 +1,11 @@
 const joinRoom = (roomTitle, namespaceId) => {
     console.log('roomTitle', roomTitle);
     console.log('namespaceId', namespaceId);
-    nameSpaceSockets[namespaceId].emit('joinRoom', roomTitle);
+    nameSpaceSockets[namespaceId].emit('joinRoom', roomTitle, (ackResp) => {
+        const numUsersDom = document.querySelector('.curr-room-num-users');
+        numUsersDom.innerHTML = `${ackResp.numUsers}<span class="fa-solid fa-user"></span>`
+
+        const roomTitleDom = document.querySelector('.curr-room-text');
+        roomTitleDom.innerHTML = roomTitle;
+    });
 };

--- a/2. slack clone/public/joinRoom.js
+++ b/2. slack clone/public/joinRoom.js
@@ -1,0 +1,5 @@
+const joinRoom = (roomTitle, namespaceId) => {
+    console.log('roomTitle', roomTitle);
+    console.log('namespaceId', namespaceId);
+    nameSpaceSockets[namespaceId].emit('joinRoom', roomTitle);
+};

--- a/2. slack clone/public/scripts.js
+++ b/2. slack clone/public/scripts.js
@@ -1,3 +1,7 @@
+/**
+ * default path로 항상 main namespace에 join한다.
+ * client가 main namespace를 통해 다른 namespace를 가져올 수 있기 때문에.
+  */
 const socket = io('http://localhost:9000');
 
 socket.on('connect', (message) => {
@@ -12,6 +16,8 @@ socket.on('nsList', (nsData) => {
     nameSpacesDiv.innerHTML = '';
     nsData.forEach((ns) => {
         nameSpacesDiv.innerHTML += `<div class="namespace" ns="${ns.endpoint}"><img src="${ns.image}"></div>`;
+        // io()를 이용해 ns에 동적으로 join한다.
+        io(`http://localhost:9000/${ns.endpoint}`, (data) => {})
     })
 
     /**

--- a/2. slack clone/public/scripts.js
+++ b/2. slack clone/public/scripts.js
@@ -4,6 +4,21 @@
   */
 const socket = io('http://localhost:9000');
 
+const nameSpaceSockets = [];
+const listeners = {
+    nsChange: [],
+}
+
+const addListeners = (nsId) => {
+    if(!listeners.nsChange[nsId]){
+        nameSpaceSockets[nsId].on('nsChange', (data) => {
+            console.log('Namespace changed');
+            console.log(data);
+        })
+        listeners.nsChange[nsId] = true;
+    }
+};
+
 socket.on('connect', (message) => {
     console.log('connected!!');
     socket.emit('clientConnected');
@@ -17,12 +32,13 @@ socket.on('nsList', (nsData) => {
     nsData.forEach((ns) => {
         nameSpacesDiv.innerHTML += `<div class="namespace" ns="${ns.endpoint}"><img src="${ns.image}"></div>`;
         // io()를 이용해 ns에 동적으로 join한다.
-        const thisNs = io(`http://localhost:9000${ns.endpoint}`);
+        //const thisNs = io(`http://localhost:9000${ns.endpoint}`);
         // 서버에서 namespace 정보가 바뀌면(nsChange 이벤트가 emit되면), 자동으로 client에도 변경사항이 전달된다.
-        thisNs.on('nsChange', (data) => {
-            console.log('Namespace changed');
-            console.log(data);
-        })
+
+        if(!nameSpaceSockets[ns.id]){
+            nameSpaceSockets[ns.id] = io(`http://localhost:9000${ns.endpoint}`);
+        }
+        addListeners(ns.id);
     })
 
     /**

--- a/2. slack clone/public/scripts.js
+++ b/2. slack clone/public/scripts.js
@@ -1,3 +1,5 @@
+const userName = 'den';
+
 /**
  * default path로 항상 main namespace에 join한다.
  * client가 main namespace를 통해 다른 namespace를 가져올 수 있기 때문에.
@@ -7,7 +9,25 @@ const socket = io('http://localhost:9000');
 const nameSpaceSockets = [];
 const listeners = {
     nsChange: [],
+    messageToRoom: [],
 }
+
+/**
+ * Global 변수인 현재 namespace Id
+ * -> namespace를 클릭하면 app 전반에 걸쳐 broadcast 하기 위한 변수
+ */
+let selectedNsId = 0;
+
+document.querySelector('#message-form').addEventListener('submit', (e) => {
+    e.preventDefault();
+    const newMessage = document.querySelector('#user-message').value;
+    nameSpaceSockets[selectedNsId].emit('newMessageToRoom', {
+        newMessage,
+        data: Date.now(),
+        avatar: 'https://via.placeholder.com/30',
+        userName,
+    })
+})
 
 const addListeners = (nsId) => {
     if(!listeners.nsChange[nsId]){
@@ -16,6 +36,12 @@ const addListeners = (nsId) => {
             console.log(data);
         })
         listeners.nsChange[nsId] = true;
+    }
+    if(!listeners.messageToRoom[nsId]){
+        nameSpaceSockets[nsId].on('messageToRoom', (messageObj) => {
+            console.log(messageObj);
+        })
+        listeners.messageToRoom[nsId] = true;
     }
 };
 

--- a/2. slack clone/public/scripts.js
+++ b/2. slack clone/public/scripts.js
@@ -17,7 +17,12 @@ socket.on('nsList', (nsData) => {
     nsData.forEach((ns) => {
         nameSpacesDiv.innerHTML += `<div class="namespace" ns="${ns.endpoint}"><img src="${ns.image}"></div>`;
         // io()를 이용해 ns에 동적으로 join한다.
-        io(`http://localhost:9000/${ns.endpoint}`, (data) => {})
+        const thisNs = io(`http://localhost:9000${ns.endpoint}`);
+        // 서버에서 namespace 정보가 바뀌면(nsChange 이벤트가 emit되면), 자동으로 client에도 변경사항이 전달된다.
+        thisNs.on('nsChange', (data) => {
+            console.log('Namespace changed');
+            console.log(data);
+        })
     })
 
     /**

--- a/2. slack clone/public/slack.html
+++ b/2. slack clone/public/slack.html
@@ -82,5 +82,6 @@
 </div>
 
 <script src="/socket.io/socket.io.js"></script>
+<script src="./joinRoom.js"></script>
 <script src="./joinNs.js"></script>
 <script src="./scripts.js"></script>

--- a/2. slack clone/public/styles.css
+++ b/2. slack clone/public/styles.css
@@ -64,7 +64,7 @@ body{
     padding-top: 10px;
 }
 .chat-panel .curr-room-text{
-    color: #fff;
+    color: #000;
     font-size: 26px;
 }
 .curr-room-num-users, .search{

--- a/2. slack clone/slack.js
+++ b/2. slack clone/slack.js
@@ -58,6 +58,18 @@ namespaces.forEach((namespace) => {
                 numUsers: socketCount,
             })
         })
+
+        socket.on('newMessageToRoom', (messageObj) => {
+            console.log(messageObj);
+
+            /**
+             * client로부터 온 이 메시지를 이 Room에 있는 모든 client에게 broadcast 해야 한다.
+             * 근데 어떻게?
+             */
+            const rooms = socket.rooms;
+            const currentRoom = [...rooms][1];
+            io.of(namespace.endpoint).in(currentRoom).emit('messageToRoom', messageObj);
+        })
     })
 })
 

--- a/2. slack clone/slack.js
+++ b/2. slack clone/slack.js
@@ -33,6 +33,11 @@ io.on('connection', (socket) => {
 namespaces.forEach((namespace) => {
     io.of(namespace.endpoint).on('connection', (socket) => {
         console.log(`${socket.id} has connected to ${namespace.endpoint}`);
+        socket.on('joinRoom', (roomTitle) => {
+            // Join Room
+            // NOTE: roomTitle is coming from the client -> Not Safe
+            socket.join(roomTitle);
+        })
     })
 })
 

--- a/2. slack clone/slack.js
+++ b/2. slack clone/slack.js
@@ -37,6 +37,14 @@ namespaces.forEach((namespace) => {
             // Join Room
             // NOTE: roomTitle is coming from the client -> Not Safe
             socket.join(roomTitle);
+
+            // 이 방의 인원을 보내준다.
+            const sockets = await io.of(namespace.endpoint).in(roomTitle).fetchSockets();
+            const socketCount = sockets.length;
+
+            ackCallback({
+                numUsers: socketCount,
+            })
         })
     })
 })

--- a/2. slack clone/slack.js
+++ b/2. slack clone/slack.js
@@ -33,7 +33,19 @@ io.on('connection', (socket) => {
 namespaces.forEach((namespace) => {
     io.of(namespace.endpoint).on('connection', (socket) => {
         console.log(`${socket.id} has connected to ${namespace.endpoint}`);
-        socket.on('joinRoom', (roomTitle) => {
+        socket.on('joinRoom', async (roomTitle, ackCallback) => {
+            // Room에 join하기 전에, client는 하나의 Room에만 참여할 수 있기 때문에 모든 방에서 leave한다.
+            // socket.rooms -> Type: Set
+            const rooms = socket.rooms;
+
+            let i = 0;
+            rooms.forEach(room => {
+                if(i !== 0) {
+                    socket.leave(room);
+                }
+                i++;
+            })
+
             // Join Room
             // NOTE: roomTitle is coming from the client -> Not Safe
             socket.join(roomTitle);

--- a/2. slack clone/slack.js
+++ b/2. slack clone/slack.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const app = express();
 const socketio = require('socket.io');
+const Room = require('./classes/Room');
 
 const namespaces = require('./data/namespace');
 
@@ -8,6 +9,16 @@ app.use(express.static(__dirname + '/public'))
 
 const expressServer = app.listen(9000);
 const io = socketio(expressServer);
+
+// manufactured way to change an namespace without building a huge UI
+app.get('/change-ns', (req, res) => {
+    // udpate namespace array
+    namespaces[0].addRoom(new Room(0, '여행방', 0));
+    // let everyone know in this namespace, that it changed
+    io.of(namespaces[0].endpoint).emit('nsChange', namespaces[0]);
+
+    res.json(namespaces[0]);
+})
 
 io.on('connection', (socket) => {
     console.log(socket.id, 'connected');

--- a/2. slack clone/slack.js
+++ b/2. slack clone/slack.js
@@ -19,3 +19,9 @@ io.on('connection', (socket) => {
     socket.emit('nsList', namespaces)
 })
 
+namespaces.forEach((namespace) => {
+    io.of(namespace.endpoint).on('connection', (socket) => {
+        console.log(`${socket.id} has connected to ${namespace.endpoint}`);
+    })
+})
+


### PR DESCRIPTION
## 📌 프로젝트명

slack clone

## 📝 주요 구현 내용

- client에서 각 namespace 클릭 시 각 namespace에 socket 연결되도록 구현
- 각 namespace의 정보(연관 Room 정보 등)을 test용으로 변경할 수 있는 endpoint 구현
  - namespace의 정보가 변경됨으로 인해 namespace data를 다시 받아올 때, 각 namespace에 socket 재연결 시도 시, 불필요한 중복 연결 요청을 하지 않도록 방지 로직 구현
- 각 namespace에 속해 있는 Room 접속 로직 구현
  - Room 접속 시 Room 이름, Room 인원이 동적으로 변경될 수 있도록 구현
  - 다른 Room 접속 시 다른 Room들은 자동으로 전부 나갈 수 있도록 구현
  - joinRoom 함수 내 로직 중, emit api의 매개변수 중 ackRsp 관련 callback 함수를 emitWithAct api를 활용해 리펙토링 진행
  - 처음 페이지 진입 시, default로 Room에 접속되게끔 구현
  - Room에서 message를 전송하면, Room에 있는 전 인원에게 message가 전달될 수 있도록 구현 

## 🤔 고민한 점, 느낀점

Namespace와 Room 연관 로직을 본격적으로 구현하고 있습니다. 아직 어려운 개념들이 많아서, 몇 번 반복 구현하면서 이해도를 높여야 될 것 같네요.

이제 슬슬 message 전송 로직을 구현할탠데 기대됩니다.